### PR TITLE
Add experimental complexity-based combination weights function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.2] - 2026-04
+
+### Added
+
+-   Added the function `share_combination_complexity_weights_rmse` to compute optimal, complexity-based regularized, constrained linear combinations using JuMP.jl with Ipopt.jl. The function requires a vector of complexity factors used to add a complexity penalty for measures with the most flexibility and/or number of parameters.
+
 ## [0.5.1] - 2025-12
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "InflationEvalTools"
 uuid = "938eba31-db9c-42f6-bde0-f3baed5865b3"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Rodrigo Chang <rrcp777@gmail.com> and DIE-BG contributors"]
 
 [deps]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -140,4 +140,5 @@ metric_combination_weights
 absme_combination_weights
 share_combination_weights_rmse
 share_combination_weights_absme
+share_combination_complexity_weights_rmse
 ```

--- a/src/InflationEvalTools.jl
+++ b/src/InflationEvalTools.jl
@@ -123,6 +123,10 @@ include("combination/combination_weights.jl")
 include("combination/metric_combination_weights.jl")
 include("combination/absme_combination_weights.jl")
 
+# Experimental functions for complexity-based combination weights
+export share_combination_complexity_weights_rmse
+include("combination/complexity_weights.jl")
+
 ## Functions in development
 
 end

--- a/src/combination/complexity_weights.jl
+++ b/src/combination/complexity_weights.jl
@@ -1,0 +1,91 @@
+# Complexity-based penalty for the inflation measures
+
+"""
+    share_combination_complexity_weights_rmse(tray_infl::AbstractArray{F,3}, tray_infl_param::AbstractArray{F,3}, complexity_factors::AbstractVector{F}, λ::AbstractFloat = 0.0) -> Vector{F}
+
+Compute a vector of non-negative weights `β` that add up to 1 by minimizing a nonlinear loss function based on the average root mean squared error (RMSE).
+
+This function differs from [`share_combination_weights_rmse`](@ref) in that it adds a complexity-based penalty to the loss function. 
+The penalty is defined as `100λ * sum(complexity_factors .* β)`, where `complexity_factors` is a vector of complexity relative weights for each inflation trajectory. 
+The penalty encourages the optimization to assign higher weights to trajectories with lower complexity, thus promoting more robust, simpler models.
+
+Arguments:
+- `tray_infl::AbstractArray{F,3}`: Simulated inflation trajectories.
+- `tray_infl_param::AbstractArray{F,3}`: Parametric inflation trajectories.
+- `complexity_factors::AbstractVector{F}`: A vector of complexity relative weights for each inflation trajectory.
+- `λ::AbstractFloat = 0.0`: Regularization parameter to penalize small weights.
+
+See also: [`share_combination_weights_rmse`](@ref)
+"""
+function share_combination_complexity_weights_rmse(
+        traj_infl::AbstractArray{F, 3},
+        traj_infl_param::AbstractArray{F, 3},
+        complexity_factors::AbstractVector{F},
+        λ::AbstractFloat = 0.0,
+    ) where {F}
+
+    T_traj, N_traj, K_traj = size(traj_infl)
+    T_param, N_param, N_batches = size(traj_infl_param)
+
+    @assert T_traj == T_param "The trajectories and the parameter should have the same number of periods."
+    @assert K_traj % N_batches == 0 "The number of trajectories should be the number of simulations times the numbers of batches."
+    @assert length(complexity_factors) == N_traj "The number of complexity factors should be equal to the number of trajectories."
+
+    # number of simulations per batch
+    N_sim = convert(Int, K_traj / N_batches)
+
+    function rmse_loss(β)
+        # The first level of the loop represents the batch in the trend simulation
+        rmse_b = Vector(undef, N_batches)
+        for b in 1:N_batches
+
+            # taking only the parameter and simulated trajectories for batch b
+            param_b = @view traj_infl_param[:, :, b]
+            traj_b = @view traj_infl[:, :, (1 + N_sim * (b - 1)):(N_sim * b)]
+
+            # The second level of the loop represents the simulations per batch
+            rmse_k = Vector(undef, N_sim)
+            for k in 1:N_sim
+                # The third level is the accumulation of the squared error
+                ∑e² = F(0)
+                for t in 1:T_traj
+                    ∑e² += (traj_b[t, :, k]' * β - param_b[t])^2
+                end
+                # computes N_sim RMSE for batch b
+                rmse_k[k] = sqrt((1 / T_traj) * ∑e²)
+            end
+            # average the k RMSEs for batch b
+            rmse_b[b] = mean(rmse_k)
+        end
+
+        # average the RMSEs across batches
+        return mean(rmse_b)
+    end
+
+    # Definition of the penalty function. it takes a mean to ensure a scalar
+    # Here we use standard Ridge regularization with different factors for each
+    # combination coefficient
+    penalty(β) = sum(complexity_factors .* (β .^ 2))
+
+    # having the loss and the penalty, define a penalized loss function for
+    # the optimizer
+    # Importantly for the calibration: the relative weight between rmse_loss and penalty is determined by λ
+    penalized_loss(β) = rmse_loss(β) + (λ * penalty(β))
+
+    # restricted optimization problem
+    model = Model(Ipopt.Optimizer)
+    @variable(model, β[1:N_traj] >= 0)
+    @constraint(model, sum(β[1:N_traj]) == 1)
+    @objective(model, Min, penalized_loss(β))
+    optimize!(model)
+
+    # extracting the optimal weights
+    β_opt = convert.(F, JuMP.value.(β))
+
+    return Dict(
+        :value => β_opt,
+        :rmse => rmse_loss(β_opt),
+        :penalty => penalty(β_opt),
+        :penalized_rmse => penalized_loss(β_opt),
+    )
+end

--- a/test/BTIMA_extension_helpers.jl
+++ b/test/BTIMA_extension_helpers.jl
@@ -1,5 +1,27 @@
 using CPIDataGT
+CPIDataGT.load_data()
 CPIDataGT.load_tree_data()
+
+## Calibration data 
+
+# Set this calibration date
+CALIB_DATE = Date(2025, 9)
+@warn "Calibration date for the matching process set to $CALIB_DATE"
+
+dates_mask = GT24.dates .<= CALIB_DATE
+FGT24_CALIB = FullCPIBase(
+    FGT24.ipc[dates_mask, :],
+    FGT24.v[dates_mask, :],
+    FGT24.w,
+    Date(2025, 1):Month(1):CALIB_DATE,
+    FGT24.baseindex,
+    FGT24.codes, 
+    FGT24.names,
+)
+
+GT24_CALIB = VarCPIBase(FGT24_CALIB)
+
+## Helper functions
 
 # Finds the indices of codes in the FullCPIBase
 findcode(code::AbstractString, base::FullCPIBase) = findfirst(==(code), base.codes)
@@ -28,9 +50,9 @@ function distrv23(i_23::Int, m::Int)
         i_24 = i_23 
     end
     # Get available observations
-    m_available = periods(GT24)
+    m_available = periods(GT24_CALIB)
     if (m <= m_available)
-        v_23 = [FGT23.v[m:12:end, i_23]..., FGT24.v[m:12:end, i_24]...]
+        v_23 = [FGT23.v[m:12:end, i_23]..., FGT24_CALIB.v[m:12:end, i_24]...]
     else
         v_23 = FGT23.v[m:12:end, i_23]
     end

--- a/test/BTIMA_extension_tests.jl
+++ b/test/BTIMA_extension_tests.jl
@@ -13,8 +13,8 @@ import Random
 CPIDataGT.load_data()
 include("BTIMA_extension_helpers.jl")  # Extension helper functions
 
-# Test data
-GT24_test = GTDATA24[Date(2025,1), Date(2025,9)].base[1]
+# Test data (from "BTIMA_extension_helpers.jl")
+GT24_test = GT24_CALIB
 
 allin(v_sample, v_collection) = all(in.(v_sample, Ref(v_collection)))
 nonein(v_sample, v_collection) = !any(in.(v_sample, Ref(v_collection)))


### PR DESCRIPTION
Introduce a new function to compute complexity-based combination weights that minimizes a nonlinear loss function incorporating a complexity penalty. This enhancement aims to promote simpler models by assigning higher weights to trajectories with lower complexity.